### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,12 +3,12 @@ name: Docker
 on:
   push:
     branches:
-      - docker
+      - master
     tags:
       - v*
 
 env:
-  IMAGE_NAME: rayyansys/prisma-flowdiagram-shinyapp
+  IMAGE_NAME: prisma-flowdiagram/prisma-flowdiagram-shinyapp
 
 jobs:
   docker:
@@ -31,7 +31,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
-          [ "$VERSION" == "docker" ] && VERSION=latest
+          [ "$VERSION" == "master" ] && VERSION=latest
 
           IMAGES=
           IMAGES="$IMAGE_ID:$VERSION"$'\n'$IMAGES

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,62 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - docker
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: rayyansys/prisma-flowdiagram-shinyapp
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Determine target image name
+        id: image-name
+        run: |
+          IMAGE_ID=ghcr.io/$IMAGE_NAME
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "docker" ] && VERSION=latest
+
+          IMAGES=
+          IMAGES="$IMAGE_ID:$VERSION"$'\n'$IMAGES
+
+          # debug output
+          echo images $IMAGES
+          echo ::set-output name=images::"$IMAGES"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.image-name.outputs.images }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM rocker/shiny:4.2.1
+
+LABEL maintainer="Hossam Hammady <hossam@rayyan.ai>"
+
+# Install system dependencies
+RUN apt-get update -qq && \
+    apt-get install -y \
+        libssl-dev \
+        libfontconfig1-dev \
+        libcurl4-openssl-dev \
+        libxml2-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        libgit2-dev \
+        libfreetype6-dev \
+        libpng-dev \
+        libtiff-dev \
+        libv8-dev \
+        librsvg2-dev \
+        libwebp-dev \
+        pandoc
+
+# Install R packages
+RUN Rscript -e 'install.packages(c("DiagrammeR", "DiagrammeRsvg", "htmltools", "htmlwidgets", "scales", "shiny", "shinyjs", "stringr", "xml2", "DT", "rio", "zip", "rsvg", "webp", "devtools"))'
+
+# Copy the shiny server configuration
+COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
+
+# Install the PRISMA2020 package
+COPY . /tmp/app
+RUN R CMD INSTALL /tmp/app
+
+# Copy the shiny app files
+COPY inst/shiny-examples/PRISMA_flowdiagram/. /srv/shiny-server/
+
+# Clean up downloaded files
+RUN rm -rf /tmp/*/downloaded_packages /tmp/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ COPY . /tmp/app
 RUN R CMD INSTALL /tmp/app
 
 # Copy the shiny app files
-COPY inst/shiny-examples/PRISMA_flowdiagram/. /srv/shiny-server/
+RUN mkdir -p /srv/shiny-server/prisma/app && \
+    echo "OK" > /srv/shiny-server/prisma/healthz.txt
+COPY inst/shiny-examples/PRISMA_flowdiagram/. /srv/shiny-server/prisma/app/
 
 # Clean up downloaded files
 RUN rm -rf /tmp/*/downloaded_packages /tmp/app

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker build . -t prisma-shiny:1
 docker run -it --rm -p 3838:3838 prisma-shiny:1
 ```
 
-Then visit http://localhost:3838 in your web browser.
+Then visit http://localhost:3838/app in your web browser.
 To stop the app, press `Ctrl+C` in the terminal.
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ A static version is produced otherwise.
 
 <a href="https://estech.shinyapps.io/prisma_flowdiagram/" target="_blank">Visit the web-based Shiny app for a point-and-click user interface here.</a>
 
+---
+## Docker Installation
+
+You can quickly install the PRISMA2020 package and run the included
+example shinyapp using [Docker](https://docs.docker.com/engine/install/).
+
+```bash
+docker build . -t prisma-shiny:1
+docker run -it --rm -p 3838:3838 prisma-shiny:1
+```
+
+Then visit http://localhost:3838 in your web browser.
+To stop the app, press `Ctrl+C` in the terminal.
+
+---
+
 Please cite as:<br>
  Haddaway, N. R., Page, M. J., Pritchard, C. C., & McGuinness, L. A. (2022). PRISMA2020: An R package and Shiny app for producing PRISMA 2020-compliant flow diagrams, with interactivity for optimised digital transparency and Open Synthesis. Campbell Systematic Reviews, 18, e1230. <a href=https://doi.org/10.1002/cl2.1230>https://doi.org/10.1002/cl2.1230</a><br>
 <a id="raw-url" href="https://raw.githubusercontent.com/nealhaddaway/PRISMA2020/master/inst/extdata/citation.ris">Citation in .ris format (right click 'Save Link As')</a>

--- a/shiny-server.conf
+++ b/shiny-server.conf
@@ -1,0 +1,18 @@
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+    # Host the directory of Shiny Apps stored in this directory
+    site_dir /srv/shiny-server;
+
+    # Log all Shiny output to files in this directory
+    log_dir /var/log/shiny-server;
+
+    # Disable directory listing
+    directory_index off;
+  }
+}

--- a/shiny-server.conf
+++ b/shiny-server.conf
@@ -7,7 +7,7 @@ server {
   # Define a location at the base URL
   location / {
     # Host the directory of Shiny Apps stored in this directory
-    site_dir /srv/shiny-server;
+    site_dir /srv/shiny-server/prisma;
 
     # Log all Shiny output to files in this directory
     log_dir /var/log/shiny-server;


### PR DESCRIPTION
This adds Docker support to simplify running the example shiny app.
No prerequisites are required except having Docker installed.
The `README.md` is also updated with build/run instructions.

It also adds a new GitHub action to build and push the docker image to GitHub container registry.
This even simplifies running the shiny app further where users can simply pull the image instead of checking out the code and building it locally.