### PR TITLE
 Fix "condition has length >1" error when single exclusion reason (closes #52)

### DIFF
--- a/PRISMA2020.Rproj
+++ b/PRISMA2020.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: f7a4cbfd-e868-459f-af75-7cfbf79ecadc
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,7 +9,7 @@
 #' @keywords internal
 PRISMA_get_height_ <- function (n, offset, min = 2) { #nolint
   lines <- n + 1
-  if (lines > min) {
+  if (isTRUE(lines > min)) {       # Fix #52: prevent length >1 error when n==1 exclusion reason
     height <- offset + (lines * 0.25) - (min * 0.25)
   } else {
     height <- offset


### PR DESCRIPTION
Diagram failing when field values are less than 2. 

Fix is an `isTRUE()` wrap around the existing utlis.R `PRISMA_get_height_` function definition.

Tested this locally with one "Reports excluded:" text field under the "Identification of new studies via databases and registers" column (works fine)

I'm happy to adjust if needed

error stems from: `data[23,8] <- "none, 0"  ## reports excluded`:

```
library(PRISMA2020)

csvFile <- system.file("extdata", "PRISMA.csv", package = "PRISMA2020")

data <- read.csv(csvFile)

##################################################################################
## Identification: (new studies via databases and registers)

data[5,8] <- 1  ## databases (NA to exclude field)
data[7,8] <- 2  ## registers (NA to exclude field)
data[13,8] <- 3 ## duplicates (NA to exclude field)
data[14,8] <- 4 ## ineligible by automation (NA to exclude field)
data[15,8] <- 5 ## removed for other reasons (NA to exclude field)

## Optional details:
data[6,8] <- "PsychInfo, 100; GoogleScholar, 200"   ## set `detail_databases=TRUE` 
data[8,8] <- "PsychInfo, 300; GoogleScholar, 400"   ## set `detail_registers=TRUE` 

##################################################################################
####### Screening:

data[16,8] <- 6   ## records screened 
data[17,8] <- 7   ## records excluded 
data[18,8] <- 8   ## reports sought for retrieval 
data[19,8] <- 9   ## reports not retrieved
data[22,8] <- 10  ## reports assessed for eligibility

## Specification:
data[23,8] <- "none, 0"  ## reports excluded

##################################################################################
####### Included:

data[26,8] <- 11  ## New studies included 
data[27,8] <- 12  ## Reports of new included studies

##################################################################################
##################################################################################
##################################################################################

prismadata <- PRISMA_data(data)

plot <- PRISMA_flowdiagram(prismadata, 
                           previous=FALSE,             ## TRUE for left-side column
                           other=FALSE,                ## TRUE for right-hand column
                           fontsize=14,
                           detail_databases=FALSE,     ## TRUE if want to specify databases
                           detail_registers=FALSE)     ## TRUE if want to specify registers

PRISMA_save(plot, filename = "prisma.png", overwrite=TRUE) 
```

error: 

```
Error in `if (lines > min) ...`:
! the condition has length > 1
Backtrace:
    ▆
 1. └─PRISMA2020::PRISMA_flowdiagram(...)
 2.   └─PRISMA2020:::PRISMA_get_height_(...)

Quitting from example.Rmd:11-65 [unnamed-chunk-1]
Execution halted
```

No error:

```
library(PRISMA2020)

unlockBinding("PRISMA_get_height_", asNamespace("PRISMA2020"))

assignInNamespace(
  "PRISMA_get_height_",
  function(n, offset, min = 2) {  
    lines <- n + 1
    if (isTRUE(lines > min)) {                                                      ####### fix: prevents length >1 error
      height <- offset + (lines * 0.25) - (min * 0.25)
    } else {
      height <- offset
    }
    return(height)
  },
  "PRISMA2020"
)

lockBinding("PRISMA_get_height_", asNamespace("PRISMA2020"))

csvFile <- system.file("extdata", "PRISMA.csv", package = "PRISMA2020")

data <- read.csv(csvFile)

##################################################################################
## Identification: (new studies via databases and registers)

data[5,8] <- 1  ## databases (NA to exclude field)
data[7,8] <- 2  ## registers (NA to exclude field)
data[13,8] <- 3 ## duplicates (NA to exclude field)
data[14,8] <- 4 ## ineligible by automation (NA to exclude field)
data[15,8] <- 5 ## removed for other reasons (NA to exclude field)

## Optional details:
data[6,8] <- "PsychInfo, 100; GoogleScholar, 200"   ## set `detail_databases=TRUE` 
data[8,8] <- "PsychInfo, 300; GoogleScholar, 400"   ## set `detail_registers=TRUE` 

##################################################################################
####### Screening:

data[16,8] <- 6   ## records screened 
data[17,8] <- 7   ## records excluded 
data[18,8] <- 8   ## reports sought for retrieval 
data[19,8] <- 9   ## reports not retrieved
data[22,8] <- 10  ## reports assessed for eligibility

## Specification:
data[23,8] <- "none, 0"  ## reports excluded

##################################################################################
####### Included:

data[26,8] <- 11  ## New studies included 
data[27,8] <- 12  ## Reports of new included studies

##################################################################################
##################################################################################
##################################################################################

prismadata <- PRISMA_data(data)

plot <- PRISMA_flowdiagram(prismadata, 
                           previous=FALSE,             ## TRUE for left-side column
                           other=FALSE,                ## TRUE for right-hand column
                           fontsize=14,
                           detail_databases=FALSE,     ## TRUE if want to specify databases
                           detail_registers=FALSE)     ## TRUE if want to specify registers

PRISMA_save(plot, filename = "prisma.png", overwrite=TRUE) 

```
