### PR TITLE
Add `rmarkdown` to `DESCRIPTION` dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     htmltools,
     htmlwidgets,
     rsvg,
+    rmarkdown,
     scales,
     shiny,
     shinyjs,


### PR DESCRIPTION
The next version of `htmlwidgets` will be moving our `rmarkdown` to a suggested dependency since it's only required for `saveWidget()`. Since your package implicitly uses that function, you'll want to explicitly add it as a hard dependency.

For more details, see https://github.com/ramnathv/htmlwidgets/pull/497